### PR TITLE
perf: combine semantic search queries

### DIFF
--- a/server/api/search/index.get.ts
+++ b/server/api/search/index.get.ts
@@ -36,11 +36,10 @@ export default defineEventHandler(async (event) => {
     consola.info(`User location: ${lat}, ${lng}`, { tag: 'geolocation' })
 
   // Hybrid search: fast text search + smart semantic matching
-  const [textResults, similarCategories] = await Promise.all([
+  const [textResults, categoryResults] = await Promise.all([
     searchLocationsByText(searchQuery),
-    searchSimilarCategories(searchQuery),
+    searchLocationsBySimilarCategories(searchQuery),
   ])
-  const categoryResults = await searchLocationsByCategories(similarCategories)
 
   // Text results prioritized - they appear first in the list
   const combinedMap = new Map<string, SearchLocationResponse>()


### PR DESCRIPTION
## Summary
- Combined `searchSimilarCategories` and `searchLocationsByCategories` into a single `searchLocationsBySimilarCategories` function
- Uses a CTE (Common Table Expression) to find similar categories and join to locations in one query
- Removed the now-unused `searchLocationsByCategories` function
- Maintains the same 5-category cap and 0.7 similarity threshold

## Performance Impact
- Reduces database round trips from 2 to 1 for semantic search
- Eliminates temporary data wiring between queries

Closes #28