### PR TITLE
fix: use waitUntil for background embedding cache

### DIFF
--- a/server/api/search/autocomplete.get.ts
+++ b/server/api/search/autocomplete.get.ts
@@ -8,7 +8,12 @@ export default defineEventHandler(async (event) => {
   const { q: searchQuery } = await getValidatedQuery(event, data => v.parse(querySchema, data))
 
   // Precompute embedding in background (non-blocking)
-  generateEmbeddingCached(searchQuery).catch(() => {})
+  // waitUntil ensures the task completes even after response is sent
+  event.waitUntil(
+    generateEmbeddingCached(searchQuery).catch((error) => {
+      console.error('[autocomplete] Failed to cache embedding:', error)
+    }),
+  )
 
   // Only text search - semantic search is too slow for autocomplete
   return await searchLocationsByText(searchQuery)


### PR DESCRIPTION
## Summary
- Replace fire-and-forget pattern with `event.waitUntil()` for background embedding cache
- Add error logging to catch failures (was silently swallowing errors)

## Why
Cloudflare Workers may terminate the execution context after the response is sent, causing background promises to be dropped. This meant embeddings weren't being cached and errors were invisible.

## Solution
Use Nitro's `event.waitUntil()` to ensure the background task completes even after the response is sent. This is the recommended pattern for Cloudflare Workers.

Closes #26