### PR TITLE
feat: add geospatial filtering at query level

### DIFF
--- a/app/components/LocationCard.vue
+++ b/app/components/LocationCard.vue
@@ -19,9 +19,16 @@ defineProps<{
         <span class="font-semibold px-8 py-4 rounded-full whitespace-nowrap text-f-xs" :class="[location.hoursStatus.variant === 'open' && 'bg-green-400 text-green-1100 outline-1.5 outline-green-400', location.hoursStatus.variant === 'closing-soon' && 'bg-orange-400 text-orange-1100 outline-1.5 outline-orange-400', location.hoursStatus.variant === 'closed' && 'bg-neutral-200 text-neutral-800', location.hoursStatus.variant === 'unavailable' && 'bg-neutral-200 text-neutral-700']">{{ $t(location.hoursStatus.messageKey) }}</span>
         <span v-if="location.hoursStatus.nextChange" text="f-xs neutral-800" whitespace-nowrap>{{ location.hoursStatus.isOpen ? 'Closes' : 'Opens' }} at <NuxtTime :datetime="location.hoursStatus.nextChange" hour="numeric" minute="2-digit" /></span>
       </div>
-      <div flex="~ items-start gap-8">
-        <Icon name="i-tabler:map-pin" text-neutral-700 mt-2 flex-shrink-0 size-16 />
-        <p text="neutral-800 f-sm" m-0 flex-1 line-clamp-2>{{ location.address }}</p>
+      <div flex="~ col gap-6">
+        <div flex="~ items-start gap-8">
+          <Icon name="i-tabler:map-pin" text-neutral-700 mt-2 flex-shrink-0 size-16 />
+          <p text="neutral-800 f-sm" m-0 flex-1 line-clamp-2>{{ location.address }}</p>
+        </div>
+        <div v-if="location.distanceMeters !== undefined" flex="~ items-center gap-8" ml-24>
+          <span text="neutral-600 f-xs" font-medium>
+            {{ location.distanceMeters < 1000 ? `${Math.round(location.distanceMeters)} m` : `${(location.distanceMeters / 1000).toFixed(1)} km` }} away
+          </span>
+        </div>
       </div>
       <div flex="~ wrap gap-6">
         <span v-for="cat in location.categories.slice(0, 3)" :key="cat.id" text="f-xs neutral-800" flex="~ items-center gap-4" font-medium px-8 py-4 rounded-full bg-neutral-100>

--- a/scripts/test-geospatial-queries.sql
+++ b/scripts/test-geospatial-queries.sql
@@ -57,12 +57,16 @@ LIMIT 10;
 -- 2. Test semantic search with geospatial filter
 -- This should also show the location_spatial_idx GIST index being used
 EXPLAIN ANALYZE
-WITH similar_categories AS (
-  SELECT id
-  FROM categories
-  WHERE embedding IS NOT NULL
-    AND 1 - (embedding <=> '[0.1, 0.2, 0.3, ...]'::vector) >= 0.7
-  ORDER BY 1 - (embedding <=> '[0.1, 0.2, 0.3, ...]'::vector) DESC
+WITH query_embedding AS (
+  -- Use the 'cafe' category embedding as our test query
+  SELECT embedding FROM categories WHERE id = 'cafe' LIMIT 1
+),
+similar_categories AS (
+  SELECT c.id
+  FROM categories c, query_embedding qe
+  WHERE c.embedding IS NOT NULL
+    AND 1 - (c.embedding <=> qe.embedding) >= 0.7
+  ORDER BY 1 - (c.embedding <=> qe.embedding) DESC
   LIMIT 5
 )
 SELECT l.uuid,

--- a/scripts/test-geospatial-queries.sql
+++ b/scripts/test-geospatial-queries.sql
@@ -1,0 +1,123 @@
+-- Test script to verify GIST index usage with EXPLAIN ANALYZE
+-- Run this against your PostgreSQL database to verify the optimizations
+
+-- 1. Test text search with geospatial filter (walkable distance)
+-- This should show the location_spatial_idx GIST index being used
+EXPLAIN ANALYZE
+WITH text_query AS (
+  SELECT l.uuid,
+         l.name,
+         l.address,
+         ST_Y(l.location) as latitude,
+         ST_X(l.location) as longitude,
+         l.rating,
+         l.photo,
+         l."gmapsPlaceId",
+         l."gmapsUrl",
+         l.website,
+         l.source,
+         l.timezone,
+         l."openingHours",
+         l."createdAt",
+         l."updatedAt",
+         ts_headline('english', l.name, to_tsquery('english', 'cafe'), 'StartSel=<mark>, StopSel=</mark>') as "highlightedName",
+         ST_Distance(
+           l.location::geography,
+           ST_SetSRID(ST_MakePoint(8.9511, 46.0037), 4326)::geography
+         ) as "distanceMeters"
+  FROM locations l
+  WHERE to_tsvector('english', l.name || ' ' || l.address) @@ to_tsquery('english', 'cafe')
+    AND ST_DWithin(
+      l.location::geography,
+      ST_SetSRID(ST_MakePoint(8.9511, 46.0037), 4326)::geography,
+      1500
+    )
+)
+SELECT tq.*,
+       STRING_AGG(lc."categoryId", ',') as "categoryIds",
+       COALESCE(
+         json_agg(
+           json_build_object(
+             'id', c.id,
+             'name', c.name,
+             'icon', c.icon
+           )
+         ) FILTER (WHERE c.id IS NOT NULL),
+         '[]'
+       ) as categories
+FROM text_query tq
+LEFT JOIN location_categories lc ON tq.uuid = lc."locationUuid"
+LEFT JOIN categories c ON lc."categoryId" = c.id
+GROUP BY tq.uuid, tq.name, tq.address, tq.latitude, tq.longitude, tq.rating, tq.photo,
+         tq."gmapsPlaceId", tq."gmapsUrl", tq.website, tq.source, tq.timezone,
+         tq."openingHours", tq."createdAt", tq."updatedAt", tq."highlightedName", tq."distanceMeters"
+ORDER BY tq."distanceMeters"
+LIMIT 10;
+
+-- 2. Test semantic search with geospatial filter
+-- This should also show the location_spatial_idx GIST index being used
+EXPLAIN ANALYZE
+WITH similar_categories AS (
+  SELECT id
+  FROM categories
+  WHERE embedding IS NOT NULL
+    AND 1 - (embedding <=> '[0.1, 0.2, 0.3, ...]'::vector) >= 0.7
+  ORDER BY 1 - (embedding <=> '[0.1, 0.2, 0.3, ...]'::vector) DESC
+  LIMIT 5
+)
+SELECT l.uuid,
+       l.name,
+       l.address,
+       ST_Y(l.location) as latitude,
+       ST_X(l.location) as longitude,
+       l.rating,
+       l.photo,
+       l."gmapsPlaceId",
+       l."gmapsUrl",
+       l.website,
+       l.source,
+       l.timezone,
+       l."openingHours",
+       l."createdAt",
+       l."updatedAt",
+       STRING_AGG(lc."categoryId", ',') as "categoryIds",
+       COALESCE(
+         json_agg(
+           json_build_object(
+             'id', c.id,
+             'name', c.name,
+             'icon', c.icon
+           )
+         ) FILTER (WHERE c.id IS NOT NULL),
+         '[]'
+       ) as categories,
+       ST_Distance(
+         l.location::geography,
+         ST_SetSRID(ST_MakePoint(8.9511, 46.0037), 4326)::geography
+       ) as "distanceMeters"
+FROM locations l
+INNER JOIN location_categories lc ON l.uuid = lc."locationUuid"
+INNER JOIN similar_categories sc ON lc."categoryId" = sc.id
+LEFT JOIN categories c ON lc."categoryId" = c.id
+WHERE ST_DWithin(
+  l.location::geography,
+  ST_SetSRID(ST_MakePoint(8.9511, 46.0037), 4326)::geography,
+  1500
+)
+GROUP BY l.uuid
+ORDER BY "distanceMeters"
+LIMIT 10;
+
+-- 3. Verify that the GIST index exists
+SELECT
+  tablename,
+  indexname,
+  indexdef
+FROM pg_indexes
+WHERE tablename = 'locations'
+  AND indexname LIKE '%spatial%';
+
+-- Expected output should show:
+-- - Index Scan or Bitmap Index Scan using location_spatial_idx
+-- - The GIST index should be used for ST_DWithin operations
+-- - Query execution time should be significantly faster than sequential scan

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -6,11 +6,20 @@ export type LocationCategory = typeof locationCategories.$inferSelect
 
 export type CategoryResponse = Pick<Category, 'id' | 'name' | 'icon'>
 
+export interface SearchLocationOptions {
+  origin?: {
+    lat: number
+    lng: number
+  }
+  maxDistanceMeters?: number
+}
+
 export type LocationResponse = Omit<Location, 'location'> & {
   latitude: number
   longitude: number
   categoryIds: string
   categories: CategoryResponse[]
+  distanceMeters?: number
 }
 
 export type SearchLocationResponse = LocationResponse & {


### PR DESCRIPTION
## Summary
- Moved walkable radius filtering into PostGIS at query level
- Added `ST_DWithin` and `ST_Distance` to search queries
- Return `distanceMeters` in results and sort by proximity
- Removed `filterByWalkableDistance` application-level filtering
- Display distance in UI when available

## Implementation
- Created `SearchLocationOptions` type with optional `origin` and `maxDistanceMeters`
- Updated `searchLocationsByText()` to accept options with geospatial filtering
- Updated `searchLocationsBySimilarCategories()` to accept options with geospatial filtering
- Modified API endpoint to pass origin coordinates and 1.5km limit when `walkable=true`
- Added optional `distanceMeters` field to `LocationResponse` type
- Updated `LocationCard.vue` to display distance (e.g., "430 m away")
- Removed obsolete `filterByWalkableDistance()` utility function

## Testing
- TypeScript compilation passes
- ESLint passes
- Created `scripts/test-geospatial-queries.sql` for EXPLAIN ANALYZE verification

## Closes
Closes https://github.com/nimiq/crypto-map-next/issues/29