### PR TITLE
fix: handle undefined result.rows in search

### DIFF
--- a/server/api/search/index.get.ts
+++ b/server/api/search/index.get.ts
@@ -52,12 +52,12 @@ export default defineEventHandler(async (event) => {
   // Text results prioritized - they appear first in the list
   const combinedMap = new Map<string, SearchLocationResponse>()
 
-  for (const loc of textResults) {
+  for (const loc of textResults || []) {
     combinedMap.set(loc.uuid, loc)
   }
 
   // Category results added only if not already matched by text search
-  for (const loc of categoryResults) {
+  for (const loc of categoryResults || []) {
     if (!combinedMap.has(loc.uuid))
       combinedMap.set(loc.uuid, loc)
   }

--- a/server/utils/search.ts
+++ b/server/utils/search.ts
@@ -112,7 +112,7 @@ export async function searchLocationsBySimilarCategories(
     LIMIT 10
   `)
 
-    return (result as any).rows as LocationResponse[]
+    return ((result as any).rows || []) as LocationResponse[]
   }
   catch (error) {
     // If semantic search fails (e.g., missing OpenAI key), fall back to empty results


### PR DESCRIPTION
## Summary
Fixes the "categoryResults is not iterable" error that occurs when semantic search returns undefined results.

## Problem
The search endpoint was failing with a 500 error because `searchLocationsBySimilarCategories` could return `undefined` when `result.rows` was undefined, despite having a try-catch block. This caused the iteration to fail with "categoryResults is not iterable".

## Solution
- Added defensive fallback `|| []` in `searchLocationsBySimilarCategories` return statement
- Added defensive fallback `|| []` in search endpoint iterations for both text and category results

## Changes
- `server/utils/search.ts`: Return `result.rows || []` to ensure array is always returned
- `server/api/search/index.get.ts`: Add `|| []` fallback when iterating results

## Testing
- ✅ Tested `/api/search?q=coffee` - returns 200 with results
- ✅ Tested `/api/search?q=restaurant` - returns 200 with results
- ✅ Typechecking passed
- ✅ Linting passed