### PR TITLE
perf: add endpoint caching strategy

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,5 +67,9 @@ export default defineNuxtConfig({
     ],
     langDir: 'locales',
   },
+  routeRules: {
+    '/api/categories': { cache: { maxAge: 3600, swr: true, staleMaxAge: 43200 } },
+    '/api/locations/**': { cache: { maxAge: 900, swr: true, staleMaxAge: 900 } },
+  },
   compatibilityDate: '2025-10-01',
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,7 +69,8 @@ export default defineNuxtConfig({
   },
   routeRules: {
     '/api/categories': { cache: { maxAge: 3600, swr: true, staleMaxAge: 43200 } },
-    '/api/locations/**': { cache: { maxAge: 900, swr: true, staleMaxAge: 900 } },
+    '/api/locations': { cache: false },
+    '/api/locations/*': { cache: { maxAge: 900, swr: true, staleMaxAge: 900 } },
   },
   compatibilityDate: '2025-10-01',
 })

--- a/server/api/categories.get.ts
+++ b/server/api/categories.get.ts
@@ -1,6 +1,6 @@
 import { desc, sql } from 'drizzle-orm'
 
-export default defineEventHandler(async () => {
+export default defineCachedEventHandler(async (event) => {
   const db = useDrizzle()
 
   // Get categories that have locations, sorted by location count
@@ -18,5 +18,10 @@ export default defineEventHandler(async () => {
     .orderBy(desc(sql`count(${tables.locationCategories.locationUuid})`))
     .limit(20)
 
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600, stale-while-revalidate=43200')
+
   return categories
+}, {
+  maxAge: 60 * 60 * 12,
+  swr: true,
 })


### PR DESCRIPTION
Implements endpoint caching for `/api/categories` and `/api/locations/[uuid]`.

Closes #54

## Changes
- Cache `/api/categories` (12h, SWR)
- Cache `/api/locations/[uuid]` (15min, SWR)
- Add routeRules for CDN/browser caching
- Document caching matrix in README