### PR TITLE
fix: apply SQL pagination instead of post-fetch slicing

### DIFF
--- a/server/api/search/autocomplete.get.ts
+++ b/server/api/search/autocomplete.get.ts
@@ -16,9 +16,8 @@ export default defineCachedEventHandler(async (event) => {
     }),
   )
 
-  const fetchLimit = 10
-  const results = await searchLocationsByText(searchQuery, { fetchLimit })
-  return results.slice(0, fetchLimit)
+  const results = await searchLocationsByText(searchQuery, { fetchLimit: 10 })
+  return results
 }, {
   maxAge: 60 * 60 * 24 * 7, // Cache for 7 days
   getKey: event => `autocomplete:${getQuery(event).q}`,


### PR DESCRIPTION
## Problem
Previously, search queries fetched up to 100 rows from the database, then sliced results in memory for pagination. This was inefficient, especially for page 1 with small limits (e.g., 10 results).

## Changes
- **Search utilities**: Added LIMIT/OFFSET support to all search functions
  - `searchLocationsByText`: Uses SQL LIMIT/OFFSET when `page` and `limit` are provided
  - `searchLocationsByCategories`: Same SQL pagination support
  - `searchLocationsBySimilarCategories`: Passes pagination params through
- **API handler**: 
  - Single-source searches (category-only): Use direct SQL pagination
  - Hybrid searches: Dynamic `fetchLimit` based on page position (`page * limit * 2`, max 200) to account for deduplication and filtering
- **Autocomplete**: Removed redundant `.slice()` since limit is already applied at SQL level
- **Type fix**: Changed URL param removal from `null` to `delete` to satisfy TypeScript

## Performance Impact
- Page 1 with limit 20: Fetches ~40 rows instead of 100 (50% reduction)
- Page 5 with limit 20: Fetches ~200 rows instead of 100 (capped for safety)

Closes #67