### PR TITLE
Use reusable SQL fragments and helper functions

### DIFF
--- a/server/api/locations/[uuid].get.ts
+++ b/server/api/locations/[uuid].get.ts
@@ -1,4 +1,5 @@
 import * as v from 'valibot'
+import { baseLocationSelect } from '../../utils/sql-fragments'
 
 const querySchema = v.object({
   uuid: v.pipe(v.string(), v.uuid()),
@@ -10,33 +11,7 @@ export default defineCachedEventHandler(async (event) => {
   const db = useDrizzle()
 
   const result = await db
-    .select({
-      uuid: tables.locations.uuid,
-      name: tables.locations.name,
-      address: sql<string>`${tables.locations.street} || ', ' || ${tables.locations.postalCode} || ' ' || ${tables.locations.city} || ', ' || ${tables.locations.country}`,
-      latitude: sql<number>`ST_Y(${tables.locations.location})`,
-      longitude: sql<number>`ST_X(${tables.locations.location})`,
-      rating: tables.locations.rating,
-      photo: tables.locations.photo,
-      gmapsPlaceId: tables.locations.gmapsPlaceId,
-      gmapsUrl: tables.locations.gmapsUrl,
-      website: tables.locations.website,
-      source: tables.locations.source,
-      timezone: tables.locations.timezone,
-      openingHours: tables.locations.openingHours,
-      createdAt: tables.locations.createdAt,
-      updatedAt: tables.locations.updatedAt,
-      categories: sql`COALESCE(
-        json_agg(
-          json_build_object(
-            'id', ${tables.categories.id},
-            'name', ${tables.categories.name},
-            'icon', ${tables.categories.icon}
-          )
-        ) FILTER (WHERE ${tables.categories.id} IS NOT NULL),
-        '[]'
-      )`,
-    })
+    .select(baseLocationSelect)
     .from(tables.locations)
     .leftJoin(tables.locationCategories, eq(tables.locations.uuid, tables.locationCategories.locationUuid))
     .leftJoin(tables.categories, eq(tables.locationCategories.categoryId, tables.categories.id))

--- a/server/utils/sql-fragments.ts
+++ b/server/utils/sql-fragments.ts
@@ -1,0 +1,264 @@
+/**
+ * SQL Fragments Utility Module
+ *
+ * This module provides reusable SQL fragments and helper functions to eliminate code duplication
+ * and ensure consistent behavior across all location-related API endpoints. All fragments are
+ * designed to work seamlessly with Drizzle ORM's query builder and type system.
+ *
+ * Key features:
+ * - Consistent address formatting across all endpoints
+ * - Standardized coordinate extraction from PostGIS geometry
+ * - Unified category aggregation with proper JSON structure
+ * - Flexible distance calculations with configurable origins
+ * - Category filtering with both AND and OR semantics
+ * - Full TypeScript support with proper type inference
+ */
+
+import type { LocationResponse } from '../../shared/types'
+import { sql } from 'drizzle-orm'
+import { tables } from './drizzle'
+
+/**
+ * Coordinate type for origin parameters in distance calculations
+ */
+export interface Coordinates {
+  lat: number
+  lng: number
+}
+
+/**
+ * Address concatenation fragment that combines street, postal code, city, and country
+ * into a formatted address string.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select({ address }).from(tables.locations)
+ */
+export const address = sql<string>`${tables.locations.street} || ', ' || ${tables.locations.postalCode} || ' ' || ${tables.locations.city} || ', ' || ${tables.locations.country}`.as('address')
+
+/**
+ * Latitude extraction fragment that extracts the Y coordinate from PostGIS point geometry.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select({ latitude }).from(tables.locations)
+ */
+export const latitude = sql<number>`ST_Y(${tables.locations.location})`.as('latitude')
+
+/**
+ * Longitude extraction fragment that extracts the X coordinate from PostGIS point geometry.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select({ longitude }).from(tables.locations)
+ */
+export const longitude = sql<number>`ST_X(${tables.locations.location})`.as('longitude')
+
+/**
+ * Categories aggregation fragment that creates a JSON array of category objects
+ * with proper handling of NULL values.
+ *
+ * @example
+ * // Usage in a query with joins:
+ * db.select({ categories: categoriesAgg })
+ *   .from(tables.locations)
+ *   .leftJoin(tables.locationCategories, eq(tables.locations.uuid, tables.locationCategories.locationUuid))
+ *   .leftJoin(tables.categories, eq(tables.locationCategories.categoryId, tables.categories.id))
+ *   .groupBy(tables.locations.uuid)
+ */
+export const categoriesAgg = sql<LocationResponse['categories']>`COALESCE(
+  json_agg(
+    json_build_object(
+      'id', ${tables.categories.id},
+      'name', ${tables.categories.name},
+      'icon', ${tables.categories.icon}
+    )
+  ) FILTER (WHERE ${tables.categories.id} IS NOT NULL),
+  '[]'
+)`.as('categories')
+
+/**
+ * Distance calculation factory function that creates a SQL fragment for calculating
+ * the distance in meters between a location and an origin point.
+ *
+ * @param origin - The origin coordinates (latitude and longitude)
+ * @returns SQL fragment that calculates distance in meters
+ *
+ * @example
+ * // Usage in a query:
+ * const origin = { lat: 46.005030, lng: 8.956060 }
+ * db.select({ distanceMeters: distance(origin) }).from(tables.locations)
+ */
+export function distance(origin: Coordinates) {
+  return sql<number>`ST_Distance(
+    ${tables.locations.location}::geography,
+    ST_SetSRID(ST_MakePoint(${origin.lng}, ${origin.lat}), 4326)::geography
+  )`.as('distanceMeters')
+}
+
+/**
+ * Geospatial filter factory function that creates a WHERE condition for locations
+ * within a specified distance from an origin point.
+ *
+ * @param origin - The origin coordinates (latitude and longitude)
+ * @param maxDistanceMeters - Maximum distance in meters
+ * @returns SQL fragment for use in WHERE clauses
+ *
+ * @example
+ * // Usage in a query:
+ * const origin = { lat: 46.005030, lng: 8.956060 }
+ * db.select().from(tables.locations)
+ *   .where(withinDistance(origin, 1000)) // Within 1km
+ */
+export function withinDistance(origin: Coordinates, maxDistanceMeters: number) {
+  return sql`ST_DWithin(
+    ${tables.locations.location}::geography,
+    ST_SetSRID(ST_MakePoint(${origin.lng}, ${origin.lat}), 4326)::geography,
+    ${maxDistanceMeters}
+  )`
+}
+
+/**
+ * Category filter helper with AND semantics - locations must match ALL specified categories.
+ * Use this when you need locations that have multiple specific categories.
+ *
+ * @param categories - Array of category IDs that locations must have
+ * @returns SQL fragment for use in WHERE clauses
+ *
+ * @example
+ * // Usage in a query:
+ * db.select().from(tables.locations)
+ *   .where(categoryFilter(['restaurant', 'outdoor_seating'])) // Must be restaurant AND have outdoor seating
+ */
+export function categoryFilter(categories: string[]) {
+  if (!categories || categories.length === 0) {
+    return sql`TRUE` // No-op condition
+  }
+
+  // AND semantics: location must have ALL specified categories
+  const subqueries = categories.map(categoryId =>
+    sql`EXISTS (
+      SELECT 1 FROM ${tables.locationCategories} 
+      WHERE ${tables.locationCategories.locationUuid} = ${tables.locations.uuid} 
+      AND ${tables.locationCategories.categoryId} = ${categoryId}
+    )`,
+  )
+
+  return sql.join(subqueries, sql` AND `)
+}
+
+/**
+ * Category filter helper with OR semantics - locations must match ANY of the specified categories.
+ * Use this for search functionality and contextual carousels where you want to show
+ * locations that match any of the related categories.
+ *
+ * @param categories - Array of category IDs that locations can have
+ * @returns SQL fragment for use in WHERE clauses
+ *
+ * @example
+ * // Usage in a query:
+ * db.select().from(tables.locations)
+ *   .where(categoryFilterOr(['restaurant', 'cafe', 'bakery'])) // Morning food options
+ */
+export function categoryFilterOr(categories: string[]) {
+  if (!categories || categories.length === 0) {
+    return sql`TRUE`
+  }
+
+  const categoryConditions = categories.map(cat =>
+    sql`${tables.locationCategories.categoryId} = ${cat}`,
+  )
+
+  return sql`${tables.locations.uuid} IN (
+    SELECT ${tables.locationCategories.locationUuid}
+    FROM ${tables.locationCategories}
+    WHERE ${sql.join(categoryConditions, sql` OR `)}
+  )`
+}
+
+/**
+ * Base location select object using SQL fragments for consistent data formatting.
+ * This replaces the inline locationSelect objects used throughout the codebase.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select(baseLocationSelect)
+ *   .from(tables.locations)
+ *   .leftJoin(tables.locationCategories, eq(tables.locations.uuid, tables.locationCategories.locationUuid))
+ *   .leftJoin(tables.categories, eq(tables.locationCategories.categoryId, tables.categories.id))
+ *   .groupBy(tables.locations.uuid)
+ */
+export const baseLocationSelect = {
+  uuid: tables.locations.uuid,
+  name: tables.locations.name,
+  address,
+  latitude,
+  longitude,
+  rating: tables.locations.rating,
+  photo: tables.locations.photo,
+  gmapsPlaceId: tables.locations.gmapsPlaceId,
+  gmapsUrl: tables.locations.gmapsUrl,
+  website: tables.locations.website,
+  source: tables.locations.source,
+  timezone: tables.locations.timezone,
+  openingHours: tables.locations.openingHours,
+  createdAt: tables.locations.createdAt,
+  updatedAt: tables.locations.updatedAt,
+  categories: categoriesAgg,
+}
+
+/**
+ * Extended location select factory function that includes distance calculation.
+ *
+ * @param origin - The origin coordinates for distance calculation
+ * @returns Select object with all base fields plus distance
+ *
+ * @example
+ * // Usage in a query:
+ * const origin = { lat: 46.005030, lng: 8.956060 }
+ * db.select(locationSelectWithDistance(origin))
+ *   .from(tables.locations)
+ *   .leftJoin(tables.locationCategories, eq(tables.locations.uuid, tables.locationCategories.locationUuid))
+ *   .leftJoin(tables.categories, eq(tables.locationCategories.categoryId, tables.categories.id))
+ *   .groupBy(tables.locations.uuid)
+ */
+export function locationSelectWithDistance(origin: Coordinates) {
+  return {
+    ...baseLocationSelect,
+    distanceMeters: distance(origin),
+  }
+}
+
+/**
+ * Location count fragment for counting the number of unique locations associated with a category.
+ * Uses DISTINCT to ensure each location is counted only once per category.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select({ locationCount }).from(tables.categories)
+ *   .leftJoin(tables.locationCategories, categoryLocationJoin)
+ *   .groupBy(tables.categories.id)
+ */
+export const locationCount = sql<number>`count(DISTINCT ${tables.locationCategories.locationUuid})::int`.as('locationCount')
+
+/**
+ * Category-location join condition fragment for consistent joining between
+ * categories and locationCategories tables.
+ *
+ * @example
+ * // Usage in a query:
+ * db.select().from(tables.categories)
+ *   .leftJoin(tables.locationCategories, categoryLocationJoin)
+ */
+export const categoryLocationJoin = sql`${tables.categories.id} = ${tables.locationCategories.categoryId}`
+
+// Type exports for better TypeScript support
+export type AddressFragment = typeof address
+export type LatitudeFragment = typeof latitude
+export type LongitudeFragment = typeof longitude
+export type CategoriesFragment = typeof categoriesAgg
+export type DistanceFragment = ReturnType<typeof distance>
+export type LocationCountFragment = typeof locationCount
+export type CategoryLocationJoinFragment = typeof categoryLocationJoin
+export type BaseLocationSelect = typeof baseLocationSelect
+export type LocationSelectWithDistance = ReturnType<typeof locationSelectWithDistance>

--- a/tests/sql-fragments.test.ts
+++ b/tests/sql-fragments.test.ts
@@ -1,0 +1,280 @@
+import type { Coordinates } from '../server/utils/sql-fragments'
+import { sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import {
+  address,
+  baseLocationSelect,
+  categoriesAgg,
+  categoryFilter,
+  categoryFilterOr,
+  distance,
+  latitude,
+  locationSelectWithDistance,
+  longitude,
+  withinDistance,
+
+} from '../server/utils/sql-fragments'
+
+describe('sQL Fragments', () => {
+  describe('address fragment', () => {
+    it('should be an aliased SQL fragment', () => {
+      expect(address).toBeDefined()
+      expect(address.fieldAlias).toBe('address')
+      expect(address.sql).toBeDefined()
+    })
+  })
+
+  describe('latitude fragment', () => {
+    it('should be an aliased SQL fragment', () => {
+      expect(latitude).toBeDefined()
+      expect(latitude.fieldAlias).toBe('latitude')
+      expect(latitude.sql).toBeDefined()
+    })
+  })
+
+  describe('longitude fragment', () => {
+    it('should be an aliased SQL fragment', () => {
+      expect(longitude).toBeDefined()
+      expect(longitude.fieldAlias).toBe('longitude')
+      expect(longitude.sql).toBeDefined()
+    })
+  })
+
+  describe('categoriesAgg fragment', () => {
+    it('should be an aliased SQL fragment', () => {
+      expect(categoriesAgg).toBeDefined()
+      expect(categoriesAgg.fieldAlias).toBe('categories')
+      expect(categoriesAgg.sql).toBeDefined()
+    })
+  })
+
+  describe('distance factory function', () => {
+    const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
+
+    it('should generate distance fragment with valid coordinates', () => {
+      const fragment = distance(testOrigin)
+      expect(fragment).toBeDefined()
+      expect(fragment.fieldAlias).toBe('distanceMeters')
+      expect(fragment.sql).toBeDefined()
+    })
+
+    it('should handle different coordinate values', () => {
+      const origins = [
+        { lat: 0, lng: 0 },
+        { lat: -90, lng: -180 },
+        { lat: 90, lng: 180 },
+        { lat: 46.005030, lng: 8.956060 },
+      ]
+
+      origins.forEach((origin) => {
+        const fragment = distance(origin)
+        expect(fragment).toBeDefined()
+        expect(fragment.fieldAlias).toBe('distanceMeters')
+      })
+    })
+
+    it('should handle decimal coordinates', () => {
+      const origin = { lat: 46.123456789, lng: 8.987654321 }
+      const fragment = distance(origin)
+      expect(fragment).toBeDefined()
+      expect(fragment.fieldAlias).toBe('distanceMeters')
+    })
+  })
+
+  describe('withinDistance factory function', () => {
+    const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
+
+    it('should generate geospatial filter with valid parameters', () => {
+      const fragment = withinDistance(testOrigin, 1000)
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should handle different distance values', () => {
+      const distances = [100, 1000, 5000, 10000]
+
+      distances.forEach((maxDistance) => {
+        const fragment = withinDistance(testOrigin, maxDistance)
+        expect(fragment).toBeDefined()
+      })
+    })
+
+    it('should handle zero distance', () => {
+      const fragment = withinDistance(testOrigin, 0)
+      expect(fragment).toBeDefined()
+    })
+  })
+
+  describe('categoryFilter function (AND semantics)', () => {
+    it('should handle empty category array', () => {
+      const fragment = categoryFilter([])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should handle null/undefined categories', () => {
+      const fragment1 = categoryFilter(null as any)
+      const fragment2 = categoryFilter(undefined as any)
+      expect(fragment1).toBeDefined()
+      expect(fragment2).toBeDefined()
+    })
+
+    it('should generate fragment for single category', () => {
+      const fragment = categoryFilter(['restaurant'])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should generate fragment for multiple categories', () => {
+      const fragment = categoryFilter(['restaurant', 'cafe', 'bar'])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should handle special characters in category IDs', () => {
+      const categories = ['category-with-dash', 'category_with_underscore', 'category.with.dots']
+      const fragment = categoryFilter(categories)
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+  })
+
+  describe('categoryFilterOr function (OR semantics)', () => {
+    it('should handle empty category array', () => {
+      const fragment = categoryFilterOr([])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should handle null/undefined categories', () => {
+      const fragment1 = categoryFilterOr(null as any)
+      const fragment2 = categoryFilterOr(undefined as any)
+      expect(fragment1).toBeDefined()
+      expect(fragment2).toBeDefined()
+    })
+
+    it('should generate fragment for single category', () => {
+      const fragment = categoryFilterOr(['restaurant'])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should generate fragment for multiple categories', () => {
+      const fragment = categoryFilterOr(['restaurant', 'cafe', 'bar'])
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+
+    it('should handle special characters in category IDs', () => {
+      const categories = ['category-with-dash', 'category_with_underscore', 'category.with.dots']
+      const fragment = categoryFilterOr(categories)
+      expect(fragment).toBeDefined()
+      expect(fragment.queryChunks).toBeDefined()
+    })
+  })
+
+  describe('baseLocationSelect object', () => {
+    it('should contain all required location fields', () => {
+      const select = baseLocationSelect
+
+      // Check that all expected fields are present
+      expect(select.uuid).toBeDefined()
+      expect(select.name).toBeDefined()
+      expect(select.address).toBeDefined()
+      expect(select.latitude).toBeDefined()
+      expect(select.longitude).toBeDefined()
+      expect(select.rating).toBeDefined()
+      expect(select.photo).toBeDefined()
+      expect(select.gmapsPlaceId).toBeDefined()
+      expect(select.gmapsUrl).toBeDefined()
+      expect(select.website).toBeDefined()
+      expect(select.source).toBeDefined()
+      expect(select.timezone).toBeDefined()
+      expect(select.openingHours).toBeDefined()
+      expect(select.createdAt).toBeDefined()
+      expect(select.updatedAt).toBeDefined()
+      expect(select.categories).toBeDefined()
+    })
+
+    it('should use SQL fragments for computed fields', () => {
+      const select = baseLocationSelect
+
+      // Address should be the address fragment
+      expect(select.address).toBe(address)
+      expect(select.latitude).toBe(latitude)
+      expect(select.longitude).toBe(longitude)
+      expect(select.categories).toBe(categoriesAgg)
+    })
+  })
+
+  describe('locationSelectWithDistance factory function', () => {
+    const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
+
+    it('should include all base location fields', () => {
+      const select = locationSelectWithDistance(testOrigin)
+
+      // Should have all base fields
+      Object.keys(baseLocationSelect).forEach((key) => {
+        expect(select[key as keyof typeof select]).toBeDefined()
+      })
+    })
+
+    it('should add distanceMeters field', () => {
+      const select = locationSelectWithDistance(testOrigin)
+      expect(select.distanceMeters).toBeDefined()
+
+      // Should be a distance fragment
+      const distanceFragment = select.distanceMeters
+      expect(distanceFragment.fieldAlias).toBe('distanceMeters')
+    })
+
+    it('should handle different origin coordinates', () => {
+      const origins = [
+        { lat: 0, lng: 0 },
+        { lat: 46.005030, lng: 8.956060 },
+        { lat: -45.123, lng: 170.456 },
+      ]
+
+      origins.forEach((origin) => {
+        const select = locationSelectWithDistance(origin)
+        expect(select.distanceMeters).toBeDefined()
+        expect(select.distanceMeters.fieldAlias).toBe('distanceMeters')
+      })
+    })
+  })
+
+  describe('functional behavior tests', () => {
+    it('should create valid SQL fragments that can be used in queries', () => {
+      // Test that fragments can be combined with other SQL
+      const testQuery = sql`SELECT ${address}, ${latitude}, ${longitude} FROM locations`
+      expect(testQuery).toBeDefined()
+      expect(testQuery.queryChunks).toBeDefined()
+    })
+
+    it('should create category filters that return valid SQL', () => {
+      const andFilter = categoryFilter(['restaurant', 'cafe'])
+      const orFilter = categoryFilterOr(['restaurant', 'cafe'])
+
+      // Both should be valid SQL fragments
+      expect(andFilter).toBeDefined()
+      expect(orFilter).toBeDefined()
+
+      // Should be able to use in WHERE clauses
+      const testQuery1 = sql`SELECT * FROM locations WHERE ${andFilter}`
+      const testQuery2 = sql`SELECT * FROM locations WHERE ${orFilter}`
+
+      expect(testQuery1).toBeDefined()
+      expect(testQuery2).toBeDefined()
+    })
+
+    it('should create distance functions that return valid SQL', () => {
+      const origin = { lat: 46.005030, lng: 8.956060 }
+      const distanceFragment = distance(origin)
+      const withinFragment = withinDistance(origin, 1000)
+
+      // Should be able to use in SELECT and WHERE clauses
+      const testQuery = sql`SELECT ${distanceFragment} FROM locations WHERE ${withinFragment}`
+      expect(testQuery).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
Use reusable SQL fragments and helper functions to eliminate code duplication and ensure consistent behavior across all location-related API endpoints.

This closes #70.