### PR TITLE
Refactor `tests/sql-fragments.test.ts`

### DIFF
--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -18,7 +18,6 @@ const emit = defineEmits<Emits>()
 
 const query = defineModel<string | undefined>('query')
 const category = defineModel<string | undefined>('category')
-const { t } = useI18n()
 
 // Use the composable's localSearchInput for autocomplete triggering
 const { localSearchInput, clearSearch } = useSearch()
@@ -89,17 +88,6 @@ function handleClearSearch() {
   clearSearch()
   query.value = undefined
   category.value = undefined
-}
-
-function formatCategoryLabel(category: string) {
-  const translationKey = `categories.${category}`
-  const translated = t(translationKey)
-  if (translated && translated !== translationKey)
-    return translated
-  return category
-    .split('_')
-    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ')
 }
 
 const { getQuickCategories } = useSearchHistory()

--- a/tests/sql-fragments.test.ts
+++ b/tests/sql-fragments.test.ts
@@ -12,50 +12,38 @@ import {
   locationSelectWithDistance,
   longitude,
   withinDistance,
-
 } from '../server/utils/sql-fragments'
 
 describe('sQL Fragments', () => {
-  describe('address fragment', () => {
-    it('should be an aliased SQL fragment', () => {
+  describe('basic fragments', () => {
+    it('should export valid SQL fragments', () => {
+      // Test that all fragments are defined and can be used in queries
       expect(address).toBeDefined()
-      expect(address.fieldAlias).toBe('address')
-      expect(address.sql).toBeDefined()
-    })
-  })
-
-  describe('latitude fragment', () => {
-    it('should be an aliased SQL fragment', () => {
       expect(latitude).toBeDefined()
-      expect(latitude.fieldAlias).toBe('latitude')
-      expect(latitude.sql).toBeDefined()
-    })
-  })
-
-  describe('longitude fragment', () => {
-    it('should be an aliased SQL fragment', () => {
       expect(longitude).toBeDefined()
-      expect(longitude.fieldAlias).toBe('longitude')
-      expect(longitude.sql).toBeDefined()
-    })
-  })
-
-  describe('categoriesAgg fragment', () => {
-    it('should be an aliased SQL fragment', () => {
       expect(categoriesAgg).toBeDefined()
-      expect(categoriesAgg.fieldAlias).toBe('categories')
-      expect(categoriesAgg.sql).toBeDefined()
+
+      // Test that they can be used in SQL queries without throwing
+      expect(() => sql`SELECT ${address}`).not.toThrow()
+      expect(() => sql`SELECT ${latitude}`).not.toThrow()
+      expect(() => sql`SELECT ${longitude}`).not.toThrow()
+      expect(() => sql`SELECT ${categoriesAgg}`).not.toThrow()
+    })
+
+    it('should be usable in combined queries', () => {
+      expect(() => {
+        sql`SELECT ${address}, ${latitude}, ${longitude}, ${categoriesAgg} FROM locations`
+      }).not.toThrow()
     })
   })
 
   describe('distance factory function', () => {
     const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
 
-    it('should generate distance fragment with valid coordinates', () => {
+    it('should generate valid distance fragments', () => {
       const fragment = distance(testOrigin)
       expect(fragment).toBeDefined()
-      expect(fragment.fieldAlias).toBe('distanceMeters')
-      expect(fragment.sql).toBeDefined()
+      expect(() => sql`SELECT ${fragment}`).not.toThrow()
     })
 
     it('should handle different coordinate values', () => {
@@ -64,168 +52,136 @@ describe('sQL Fragments', () => {
         { lat: -90, lng: -180 },
         { lat: 90, lng: 180 },
         { lat: 46.005030, lng: 8.956060 },
+        { lat: 46.123456789, lng: 8.987654321 },
       ]
 
       origins.forEach((origin) => {
         const fragment = distance(origin)
         expect(fragment).toBeDefined()
-        expect(fragment.fieldAlias).toBe('distanceMeters')
+        expect(() => sql`SELECT ${fragment}`).not.toThrow()
       })
-    })
-
-    it('should handle decimal coordinates', () => {
-      const origin = { lat: 46.123456789, lng: 8.987654321 }
-      const fragment = distance(origin)
-      expect(fragment).toBeDefined()
-      expect(fragment.fieldAlias).toBe('distanceMeters')
     })
   })
 
   describe('withinDistance factory function', () => {
     const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
 
-    it('should generate geospatial filter with valid parameters', () => {
+    it('should generate valid geospatial filters', () => {
       const fragment = withinDistance(testOrigin, 1000)
       expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
+      expect(() => sql`SELECT * FROM locations WHERE ${fragment}`).not.toThrow()
     })
 
     it('should handle different distance values', () => {
-      const distances = [100, 1000, 5000, 10000]
+      const distances = [0, 100, 1000, 5000, 10000]
 
       distances.forEach((maxDistance) => {
         const fragment = withinDistance(testOrigin, maxDistance)
         expect(fragment).toBeDefined()
+        expect(() => sql`SELECT * FROM locations WHERE ${fragment}`).not.toThrow()
       })
-    })
-
-    it('should handle zero distance', () => {
-      const fragment = withinDistance(testOrigin, 0)
-      expect(fragment).toBeDefined()
     })
   })
 
   describe('categoryFilter function (AND semantics)', () => {
-    it('should handle empty category array', () => {
-      const fragment = categoryFilter([])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
+    it('should handle various input scenarios', () => {
+      // Test different input scenarios
+      const scenarios = [
+        [],
+        ['restaurant'],
+        ['restaurant', 'cafe', 'bar'],
+        ['category-with-dash', 'category_with_underscore', 'category.with.dots'],
+        null as any,
+        undefined as any,
+      ]
 
-    it('should handle null/undefined categories', () => {
-      const fragment1 = categoryFilter(null as any)
-      const fragment2 = categoryFilter(undefined as any)
-      expect(fragment1).toBeDefined()
-      expect(fragment2).toBeDefined()
-    })
-
-    it('should generate fragment for single category', () => {
-      const fragment = categoryFilter(['restaurant'])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
-
-    it('should generate fragment for multiple categories', () => {
-      const fragment = categoryFilter(['restaurant', 'cafe', 'bar'])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
-
-    it('should handle special characters in category IDs', () => {
-      const categories = ['category-with-dash', 'category_with_underscore', 'category.with.dots']
-      const fragment = categoryFilter(categories)
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
+      scenarios.forEach((categories) => {
+        const fragment = categoryFilter(categories)
+        expect(fragment).toBeDefined()
+        expect(() => sql`SELECT * FROM locations WHERE ${fragment}`).not.toThrow()
+      })
     })
   })
 
   describe('categoryFilterOr function (OR semantics)', () => {
-    it('should handle empty category array', () => {
-      const fragment = categoryFilterOr([])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
+    it('should handle various input scenarios', () => {
+      // Test different input scenarios
+      const scenarios = [
+        [],
+        ['restaurant'],
+        ['restaurant', 'cafe', 'bar'],
+        ['category-with-dash', 'category_with_underscore', 'category.with.dots'],
+        null as any,
+        undefined as any,
+      ]
 
-    it('should handle null/undefined categories', () => {
-      const fragment1 = categoryFilterOr(null as any)
-      const fragment2 = categoryFilterOr(undefined as any)
-      expect(fragment1).toBeDefined()
-      expect(fragment2).toBeDefined()
-    })
-
-    it('should generate fragment for single category', () => {
-      const fragment = categoryFilterOr(['restaurant'])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
-
-    it('should generate fragment for multiple categories', () => {
-      const fragment = categoryFilterOr(['restaurant', 'cafe', 'bar'])
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
-    })
-
-    it('should handle special characters in category IDs', () => {
-      const categories = ['category-with-dash', 'category_with_underscore', 'category.with.dots']
-      const fragment = categoryFilterOr(categories)
-      expect(fragment).toBeDefined()
-      expect(fragment.queryChunks).toBeDefined()
+      scenarios.forEach((categories) => {
+        const fragment = categoryFilterOr(categories)
+        expect(fragment).toBeDefined()
+        expect(() => sql`SELECT * FROM locations WHERE ${fragment}`).not.toThrow()
+      })
     })
   })
 
   describe('baseLocationSelect object', () => {
     it('should contain all required location fields', () => {
       const select = baseLocationSelect
+      const expectedFields = [
+        'uuid',
+        'name',
+        'address',
+        'latitude',
+        'longitude',
+        'rating',
+        'photo',
+        'gmapsPlaceId',
+        'gmapsUrl',
+        'website',
+        'source',
+        'timezone',
+        'openingHours',
+        'createdAt',
+        'updatedAt',
+        'categories',
+      ]
 
-      // Check that all expected fields are present
-      expect(select.uuid).toBeDefined()
-      expect(select.name).toBeDefined()
-      expect(select.address).toBeDefined()
-      expect(select.latitude).toBeDefined()
-      expect(select.longitude).toBeDefined()
-      expect(select.rating).toBeDefined()
-      expect(select.photo).toBeDefined()
-      expect(select.gmapsPlaceId).toBeDefined()
-      expect(select.gmapsUrl).toBeDefined()
-      expect(select.website).toBeDefined()
-      expect(select.source).toBeDefined()
-      expect(select.timezone).toBeDefined()
-      expect(select.openingHours).toBeDefined()
-      expect(select.createdAt).toBeDefined()
-      expect(select.updatedAt).toBeDefined()
-      expect(select.categories).toBeDefined()
+      expectedFields.forEach((field) => {
+        expect(select).toHaveProperty(field)
+        expect(select[field as keyof typeof select]).toBeDefined()
+      })
     })
 
     it('should use SQL fragments for computed fields', () => {
       const select = baseLocationSelect
 
-      // Address should be the address fragment
+      // These should be the same fragment instances
       expect(select.address).toBe(address)
       expect(select.latitude).toBe(latitude)
       expect(select.longitude).toBe(longitude)
       expect(select.categories).toBe(categoriesAgg)
+    })
+
+    it('should be usable in queries', () => {
+      expect(() => {
+        const fields = Object.values(baseLocationSelect)
+        sql`SELECT ${sql.join(fields, sql`, `)} FROM locations`
+      }).not.toThrow()
     })
   })
 
   describe('locationSelectWithDistance factory function', () => {
     const testOrigin: Coordinates = { lat: 46.005030, lng: 8.956060 }
 
-    it('should include all base location fields', () => {
+    it('should include all base location fields plus distance', () => {
       const select = locationSelectWithDistance(testOrigin)
 
       // Should have all base fields
       Object.keys(baseLocationSelect).forEach((key) => {
         expect(select[key as keyof typeof select]).toBeDefined()
       })
-    })
 
-    it('should add distanceMeters field', () => {
-      const select = locationSelectWithDistance(testOrigin)
+      // Should have distance field
       expect(select.distanceMeters).toBeDefined()
-
-      // Should be a distance fragment
-      const distanceFragment = select.distanceMeters
-      expect(distanceFragment.fieldAlias).toBe('distanceMeters')
     })
 
     it('should handle different origin coordinates', () => {
@@ -238,43 +194,123 @@ describe('sQL Fragments', () => {
       origins.forEach((origin) => {
         const select = locationSelectWithDistance(origin)
         expect(select.distanceMeters).toBeDefined()
-        expect(select.distanceMeters.fieldAlias).toBe('distanceMeters')
+        expect(() => sql`SELECT ${select.distanceMeters} FROM locations`).not.toThrow()
       })
+    })
+
+    it('should be usable in complete queries', () => {
+      const select = locationSelectWithDistance(testOrigin)
+      expect(() => {
+        const fields = Object.values(select)
+        sql`SELECT ${sql.join(fields, sql`, `)} FROM locations`
+      }).not.toThrow()
     })
   })
 
-  describe('functional behavior tests', () => {
-    it('should create valid SQL fragments that can be used in queries', () => {
-      // Test that fragments can be combined with other SQL
-      const testQuery = sql`SELECT ${address}, ${latitude}, ${longitude} FROM locations`
-      expect(testQuery).toBeDefined()
-      expect(testQuery.queryChunks).toBeDefined()
+  describe('integration behavior', () => {
+    it('should allow combining fragments in complex queries', () => {
+      const origin = { lat: 46.005030, lng: 8.956060 }
+      const select = locationSelectWithDistance(origin)
+      const categoryCondition = categoryFilterOr(['restaurant', 'cafe'])
+      const distanceCondition = withinDistance(origin, 2000)
+
+      expect(() => {
+        const fields = Object.values(select)
+        sql`
+          SELECT ${sql.join(fields, sql`, `)}
+          FROM locations 
+          LEFT JOIN location_categories ON locations.uuid = location_categories.location_uuid
+          LEFT JOIN categories ON location_categories.category_id = categories.id
+          WHERE ${categoryCondition} AND ${distanceCondition}
+          GROUP BY locations.uuid
+          ORDER BY ${select.distanceMeters}
+        `
+      }).not.toThrow()
     })
 
-    it('should create category filters that return valid SQL', () => {
-      const andFilter = categoryFilter(['restaurant', 'cafe'])
-      const orFilter = categoryFilterOr(['restaurant', 'cafe'])
+    it('should create different behavior for AND vs OR category filters', () => {
+      const categories = ['restaurant', 'cafe']
+      const andFilter = categoryFilter(categories)
+      const orFilter = categoryFilterOr(categories)
 
-      // Both should be valid SQL fragments
+      // Both should be valid but different objects
       expect(andFilter).toBeDefined()
       expect(orFilter).toBeDefined()
+      expect(andFilter).not.toBe(orFilter)
 
-      // Should be able to use in WHERE clauses
-      const testQuery1 = sql`SELECT * FROM locations WHERE ${andFilter}`
-      const testQuery2 = sql`SELECT * FROM locations WHERE ${orFilter}`
-
-      expect(testQuery1).toBeDefined()
-      expect(testQuery2).toBeDefined()
+      // Both should be usable in queries
+      expect(() => {
+        sql`SELECT * FROM locations WHERE ${andFilter}`
+        sql`SELECT * FROM locations WHERE ${orFilter}`
+      }).not.toThrow()
     })
 
-    it('should create distance functions that return valid SQL', () => {
-      const origin = { lat: 46.005030, lng: 8.956060 }
-      const distanceFragment = distance(origin)
-      const withinFragment = withinDistance(origin, 1000)
+    it('should handle edge cases gracefully', () => {
+      // Test various edge cases don't throw errors
+      expect(() => {
+        categoryFilter([])
+        categoryFilterOr([])
+        categoryFilter(null as any)
+        categoryFilterOr(undefined as any)
+        distance({ lat: 0, lng: 0 })
+        withinDistance({ lat: 0, lng: 0 }, 0)
 
-      // Should be able to use in SELECT and WHERE clauses
-      const testQuery = sql`SELECT ${distanceFragment} FROM locations WHERE ${withinFragment}`
-      expect(testQuery).toBeDefined()
+        // Test extreme coordinates
+        distance({ lat: 90, lng: 180 })
+        distance({ lat: -90, lng: -180 })
+        withinDistance({ lat: 90, lng: 180 }, 0)
+        withinDistance({ lat: -90, lng: -180 }, 999999)
+      }).not.toThrow()
+    })
+
+    it('should maintain consistent behavior across multiple calls', () => {
+      // Test that fragments are reusable and consistent
+      const origin = { lat: 46.005030, lng: 8.956060 }
+
+      const fragment1 = distance(origin)
+      const fragment2 = distance(origin)
+
+      // Should both be valid (though not necessarily identical objects)
+      expect(fragment1).toBeDefined()
+      expect(fragment2).toBeDefined()
+
+      expect(() => {
+        sql`SELECT ${fragment1} FROM locations`
+        sql`SELECT ${fragment2} FROM locations`
+      }).not.toThrow()
+    })
+
+    it('should work with realistic query patterns', () => {
+      const origin = { lat: 46.005030, lng: 8.956060 }
+
+      // Test patterns that would be used in real application code
+      expect(() => {
+        // Basic location query
+        sql`SELECT ${sql.join(Object.values(baseLocationSelect), sql`, `)} FROM locations`
+
+        // Location query with distance
+        const selectWithDistance = locationSelectWithDistance(origin)
+        sql`SELECT ${sql.join(Object.values(selectWithDistance), sql`, `)} FROM locations`
+
+        // Filtered location query
+        const categoryCondition = categoryFilter(['restaurant'])
+        sql`
+          SELECT ${sql.join(Object.values(baseLocationSelect), sql`, `)}
+          FROM locations 
+          WHERE ${categoryCondition}
+        `
+
+        // Complex filtered query with distance
+        const orCondition = categoryFilterOr(['restaurant', 'cafe'])
+        const distanceCondition = withinDistance(origin, 1000)
+        sql`
+          SELECT ${sql.join(Object.values(selectWithDistance), sql`, `)}
+          FROM locations 
+          WHERE ${orCondition} AND ${distanceCondition}
+          ORDER BY ${selectWithDistance.distanceMeters}
+          LIMIT 10
+        `
+      }).not.toThrow()
     })
   })
 })


### PR DESCRIPTION
Refactor `tests/sql-fragments.test.ts` to move away from testing internal Drizzle implementation details and instead focus on integration-style testing that validates actual behavior.

This closes #76.