### PR TITLE
Add query param to move the search bar to the bottom

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -3,6 +3,10 @@
 </template>
 
 <style>
+:root {
+  --safe-area-inset-bottom-px: env(safe-area-inset-bottom, 0px);
+}
+
 html,
 body {
   height: 100dvh;

--- a/app/components/CountryBubbles.vue
+++ b/app/components/CountryBubbles.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import type { Map as MapLibreMap } from 'maplibre-gl'
+import type { SearchBarPosition } from '../utils/search-bar-position'
 import { icons as flagIcons } from '@iconify-json/flag'
 import { Marker } from 'maplibre-gl'
+import { SEARCH_BAR_BOTTOM_UI_OFFSET_PX } from '../utils/search-bar-position'
+
+const props = withDefaults(defineProps<{
+  searchBarPosition?: SearchBarPosition
+}>(), {
+  searchBarPosition: 'top',
+})
 
 const { t } = useI18n()
 
@@ -121,10 +129,11 @@ function getEdgePosition(bearing: number, vpWidth: number, vpHeight: number): { 
   const angle = (90 - bearing) * Math.PI / 180
   const centerX = vpWidth / 2
   const centerY = vpHeight / 2
+  const bottomReservedSpace = props.searchBarPosition === 'bottom' ? SEARCH_BAR_BOTTOM_UI_OFFSET_PX : 0
 
   const maxX = vpWidth - BUBBLE_PADDING - BUBBLE_WIDTH / 2
   const minX = BUBBLE_PADDING + BUBBLE_WIDTH / 2
-  const maxY = vpHeight - BUBBLE_PADDING - BUBBLE_HEIGHT / 2
+  const maxY = vpHeight - BUBBLE_PADDING - BUBBLE_HEIGHT / 2 - bottomReservedSpace
   const minY = BUBBLE_PADDING + BUBBLE_HEIGHT / 2 + 60
 
   const dx = Math.cos(angle)

--- a/app/components/CountryBubbles.vue
+++ b/app/components/CountryBubbles.vue
@@ -3,7 +3,10 @@ import type { Map as MapLibreMap } from 'maplibre-gl'
 import type { SearchBarPosition } from '../utils/search-bar-position'
 import { icons as flagIcons } from '@iconify-json/flag'
 import { Marker } from 'maplibre-gl'
-import { SEARCH_BAR_BOTTOM_UI_OFFSET_PX } from '../utils/search-bar-position'
+import {
+  getBottomSafeAreaInsetPx,
+  SEARCH_BAR_BOTTOM_UI_OFFSET_PX,
+} from '../utils/search-bar-position'
 
 const props = withDefaults(defineProps<{
   searchBarPosition?: SearchBarPosition
@@ -129,7 +132,9 @@ function getEdgePosition(bearing: number, vpWidth: number, vpHeight: number): { 
   const angle = (90 - bearing) * Math.PI / 180
   const centerX = vpWidth / 2
   const centerY = vpHeight / 2
-  const bottomReservedSpace = props.searchBarPosition === 'bottom' ? SEARCH_BAR_BOTTOM_UI_OFFSET_PX : 0
+  const bottomReservedSpace = props.searchBarPosition === 'bottom'
+    ? SEARCH_BAR_BOTTOM_UI_OFFSET_PX + getBottomSafeAreaInsetPx()
+    : 0
 
   const maxX = vpWidth - BUBBLE_PADDING - BUBBLE_WIDTH / 2
   const minX = BUBBLE_PADDING + BUBBLE_WIDTH / 2

--- a/app/components/LocationCounter.vue
+++ b/app/components/LocationCounter.vue
@@ -2,6 +2,7 @@
 import type { SearchBarPosition } from '../utils/search-bar-position'
 import { consola } from 'consola'
 import { animate, useMotionValue } from 'motion-v'
+import { SEARCH_BAR_BOTTOM_COUNTER_OFFSET_PX } from '../utils/search-bar-position'
 
 const props = withDefaults(defineProps<{
   searchBarPosition?: SearchBarPosition
@@ -13,9 +14,11 @@ const { t } = useI18n()
 const { mapInstance } = useMapControls()
 const { locationCount, clusterCount } = useVisibleLocations()
 const { showDelayedLoading, setCountPending } = useLocationLoadingState()
-const bottomOffsetClass = computed(() => props.searchBarPosition === 'bottom'
-  ? 'bottom-[calc(84px+env(safe-area-inset-bottom))]'
-  : 'bottom-8')
+const bottomOffsetStyle = computed(() => ({
+  bottom: props.searchBarPosition === 'bottom'
+    ? `calc(${SEARCH_BAR_BOTTOM_COUNTER_OFFSET_PX}px + env(safe-area-inset-bottom))`
+    : '8px',
+}))
 const hasVisibleFeatures = computed(() => locationCount.value > 0 || clusterCount.value > 0)
 const count = ref<number | null>(null)
 const shouldShowPill = computed(() => {
@@ -97,7 +100,7 @@ onBeforeUnmount(() => {
     <div
       v-if="shouldShowPill"
       flex pointer-events-none left-0 right-0 justify-center fixed z-10
-      :class="bottomOffsetClass"
+      :style="bottomOffsetStyle"
     >
       <div
         flex="~ items-center gap-8"

--- a/app/components/LocationCounter.vue
+++ b/app/components/LocationCounter.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
+import type { SearchBarPosition } from '../utils/search-bar-position'
 import { consola } from 'consola'
 import { animate, useMotionValue } from 'motion-v'
+
+const props = withDefaults(defineProps<{
+  searchBarPosition?: SearchBarPosition
+}>(), {
+  searchBarPosition: 'top',
+})
 
 const { t } = useI18n()
 const { mapInstance } = useMapControls()
 const { locationCount, clusterCount } = useVisibleLocations()
 const { showDelayedLoading, setCountPending } = useLocationLoadingState()
+const bottomOffsetClass = computed(() => props.searchBarPosition === 'bottom'
+  ? 'bottom-[calc(84px+env(safe-area-inset-bottom))]'
+  : 'bottom-8')
 const hasVisibleFeatures = computed(() => locationCount.value > 0 || clusterCount.value > 0)
 const count = ref<number | null>(null)
 const shouldShowPill = computed(() => {
@@ -86,7 +96,8 @@ onBeforeUnmount(() => {
   >
     <div
       v-if="shouldShowPill"
-      flex pointer-events-none bottom-8 left-0 right-0 justify-center fixed z-10
+      flex pointer-events-none left-0 right-0 justify-center fixed z-10
+      :class="bottomOffsetClass"
     >
       <div
         flex="~ items-center gap-8"

--- a/app/components/MapControls.vue
+++ b/app/components/MapControls.vue
@@ -1,7 +1,18 @@
 <script setup lang="ts">
+import type { SearchBarPosition } from '../utils/search-bar-position'
+
+const props = withDefaults(defineProps<{
+  searchBarPosition?: SearchBarPosition
+}>(), {
+  searchBarPosition: 'top',
+})
+
 const { zoomIn, zoomOut, flyTo, bearing, isRotated, resetNorth } = useMapControls()
 const { hasPointer } = usePointerType()
 const { isLocating, locateMe, gpsPoint, gpsAccuracy, showUserLocation } = useUserLocation()
+const bottomOffsetClass = computed(() => props.searchBarPosition === 'bottom'
+  ? 'bottom-[calc(88px+env(safe-area-inset-bottom))] md:bottom-[calc(92px+env(safe-area-inset-bottom))]'
+  : 'bottom-12 md:bottom-16')
 
 function handleLocateMe() {
   locateMe()
@@ -13,7 +24,7 @@ function handleLocateMe() {
 </script>
 
 <template>
-  <div flex="~ col gap-8" bottom="12 md:16" right="12 md:16" absolute z-10>
+  <div flex="~ col gap-8" right="12 md:16" absolute z-10 :class="bottomOffsetClass">
     <Motion
       is="button"
       v-if="isRotated"

--- a/app/components/MapControls.vue
+++ b/app/components/MapControls.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 import type { SearchBarPosition } from '../utils/search-bar-position'
+import {
+  SEARCH_BAR_BOTTOM_UI_OFFSET_MD_PX,
+  SEARCH_BAR_BOTTOM_UI_OFFSET_PX,
+} from '../utils/search-bar-position'
 
 const props = withDefaults(defineProps<{
   searchBarPosition?: SearchBarPosition
@@ -10,9 +14,18 @@ const props = withDefaults(defineProps<{
 const { zoomIn, zoomOut, flyTo, bearing, isRotated, resetNorth } = useMapControls()
 const { hasPointer } = usePointerType()
 const { isLocating, locateMe, gpsPoint, gpsAccuracy, showUserLocation } = useUserLocation()
-const bottomOffsetClass = computed(() => props.searchBarPosition === 'bottom'
-  ? 'bottom-[calc(88px+env(safe-area-inset-bottom))] md:bottom-[calc(92px+env(safe-area-inset-bottom))]'
-  : 'bottom-12 md:bottom-16')
+const { width: windowWidth } = useWindowSize()
+const bottomOffsetStyle = computed(() => {
+  const bottomOffset = props.searchBarPosition === 'bottom'
+    ? (windowWidth.value >= 768 ? SEARCH_BAR_BOTTOM_UI_OFFSET_MD_PX : SEARCH_BAR_BOTTOM_UI_OFFSET_PX)
+    : (windowWidth.value >= 768 ? 16 : 12)
+
+  return {
+    bottom: props.searchBarPosition === 'bottom'
+      ? `calc(${bottomOffset}px + env(safe-area-inset-bottom))`
+      : `${bottomOffset}px`,
+  }
+})
 
 function handleLocateMe() {
   locateMe()
@@ -24,7 +37,7 @@ function handleLocateMe() {
 </script>
 
 <template>
-  <div flex="~ col gap-8" right="12 md:16" absolute z-10 :class="bottomOffsetClass">
+  <div flex="~ col gap-8" right="12 md:16" absolute z-10 :style="bottomOffsetStyle">
     <Motion
       is="button"
       v-if="isRotated"

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
 import type { ComboboxInput } from 'reka-ui'
 import type { SearchBarPosition } from '../utils/search-bar-position'
-
-const props = withDefaults(defineProps<Props>(), {
-  position: 'top',
-})
-
-const emit = defineEmits<Emits>()
-
-const { t } = useI18n()
+import {
+  getSearchBarNavigationQuery,
+} from '../utils/search-bar-position'
 
 type SearchItem
   = | { kind: 'location', uuid: string, name: string, latitude: number, longitude: number }
@@ -25,6 +20,14 @@ interface Props {
 interface Emits {
   (e: 'navigate', uuid: string | undefined, latitude: number, longitude: number): void
 }
+
+const props = withDefaults(defineProps<Props>(), {
+  position: 'top',
+})
+const emit = defineEmits<Emits>()
+const route = useRoute()
+
+const { t } = useI18n()
 
 const query = defineModel<string | undefined>('query')
 const category = defineModel<string | undefined>('category')
@@ -146,13 +149,19 @@ async function handleItemClick(item: SearchItem) {
       query.value = item.query
       category.value = undefined
       collapseCombobox()
-      await navigateTo('/')
+      await navigateTo({
+        path: '/',
+        query: getSearchBarNavigationQuery(route.query, props.position),
+      })
       break
     case 'category':
       category.value = item.category
       query.value = undefined
       collapseCombobox()
-      await navigateTo('/')
+      await navigateTo({
+        path: '/',
+        query: getSearchBarNavigationQuery(route.query, props.position),
+      })
       break
     case 'geo':
       emit('navigate', undefined, item.latitude, item.longitude)

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -3,6 +3,7 @@ import type { ComboboxInput } from 'reka-ui'
 import type { SearchBarPosition } from '../utils/search-bar-position'
 import {
   getSearchBarNavigationQuery,
+  SEARCH_BAR_BOTTOM_SAFE_OFFSET_PX,
 } from '../utils/search-bar-position'
 
 type SearchItem
@@ -45,13 +46,15 @@ const searchQuery = computed({
 
 const isComboboxOpen = ref(false)
 const isBottomPosition = computed(() => props.position === 'bottom')
-const anchorClass = computed(() => isBottomPosition.value ? 'bottom-0' : 'top-0')
 const searchContainerClass = computed(() => isBottomPosition.value
-  ? 'mb-[max(12px,env(safe-area-inset-bottom))]'
+  ? ''
   : 'mt-12')
 const contentInsetClass = computed(() => isBottomPosition.value
   ? 'pb-[calc(56px+max(12px,env(safe-area-inset-bottom)))] md:pb-[calc(60px+max(12px,env(safe-area-inset-bottom)))]'
   : 'pt-56 md:pt-60')
+const anchorStyle = computed(() => isBottomPosition.value
+  ? { bottom: `max(${SEARCH_BAR_BOTTOM_SAFE_OFFSET_PX}px, env(safe-area-inset-bottom))` }
+  : { top: '0px' })
 const searchDisplayValue = computed(() => {
   const label = categorySuggestion.value
     ? formatCategoryLabel(categorySuggestion.value.categoryId)
@@ -200,7 +203,7 @@ async function handleItemClick(item: SearchItem) {
       </ComboboxItem>
     </DefineComboboxItemTemplate>
 
-    <ComboboxAnchor as="div" inset-x-0 absolute z-60 :class="anchorClass">
+    <ComboboxAnchor as="div" inset-x-0 absolute z-60 :style="anchorStyle">
       <div px-12 w-screen relative :class="searchContainerClass">
         <ComboboxInput ref="search-input" v-model="searchQuery" outline="0.5 neutral-400" name="search" :placeholder="t('search.placeholder')" v-bind="$attrs" text-neutral px-47 pb-12 pt-10 rounded-full bg-neutral-0 w-full shadow transition-colors />
         <button p-0 border-0 bg-transparent cursor-pointer translate-y-13.5 left-28 top-0 absolute @click="handleClose">

--- a/app/components/Search.vue
+++ b/app/components/Search.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import type { ComboboxInput } from 'reka-ui'
+import type { SearchBarPosition } from '../utils/search-bar-position'
 
-defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  position: 'top',
+})
 
 const emit = defineEmits<Emits>()
 
@@ -14,6 +17,7 @@ type SearchItem
     | { kind: 'geo', name: string, displayName: string, latitude: number, longitude: number, geoType: GeoType }
 
 interface Props {
+  position?: SearchBarPosition
   autocompleteLocations?: SearchLocationResponse[]
   autocompleteGeo?: GeoResult[] // Strong matches (before locations)
   autocompleteGeoWeak?: GeoResult[] // Weak matches (after locations)
@@ -37,6 +41,14 @@ const searchQuery = computed({
 })
 
 const isComboboxOpen = ref(false)
+const isBottomPosition = computed(() => props.position === 'bottom')
+const anchorClass = computed(() => isBottomPosition.value ? 'bottom-0' : 'top-0')
+const searchContainerClass = computed(() => isBottomPosition.value
+  ? 'mb-[max(12px,env(safe-area-inset-bottom))]'
+  : 'mt-12')
+const contentInsetClass = computed(() => isBottomPosition.value
+  ? 'pb-[calc(56px+max(12px,env(safe-area-inset-bottom)))] md:pb-[calc(60px+max(12px,env(safe-area-inset-bottom)))]'
+  : 'pt-56 md:pt-60')
 const searchDisplayValue = computed(() => {
   const label = categorySuggestion.value
     ? formatCategoryLabel(categorySuggestion.value.categoryId)
@@ -179,8 +191,8 @@ async function handleItemClick(item: SearchItem) {
       </ComboboxItem>
     </DefineComboboxItemTemplate>
 
-    <ComboboxAnchor as="div" inset-x-0 top-0 absolute z-60>
-      <div mt-12 px-12 w-screen relative>
+    <ComboboxAnchor as="div" inset-x-0 absolute z-60 :class="anchorClass">
+      <div px-12 w-screen relative :class="searchContainerClass">
         <ComboboxInput ref="search-input" v-model="searchQuery" outline="0.5 neutral-400" name="search" :placeholder="t('search.placeholder')" v-bind="$attrs" text-neutral px-47 pb-12 pt-10 rounded-full bg-neutral-0 w-full shadow transition-colors />
         <button p-0 border-0 bg-transparent cursor-pointer translate-y-13.5 left-28 top-0 absolute @click="handleClose">
           <Icon v-if="!isComboboxOpen" name="i-tabler:search" op-70 size-18 />
@@ -196,7 +208,7 @@ async function handleItemClick(item: SearchItem) {
     </ComboboxAnchor>
 
     <ComboboxPortal>
-      <ComboboxContent position="inline" flex="~ col" bg-neutral-100 inset-0 fixed z-50 pt="56 md:60">
+      <ComboboxContent position="inline" flex="~ col" bg-neutral-100 inset-0 fixed z-50 :class="contentInsetClass">
         <ComboboxViewport flex="~ col" h-full of-auto>
           <div flex="~ col" h-full f-px-md f-pt-sm>
             <template v-if="showQuickCategories">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Map, MapMouseEvent } from 'maplibre-gl'
 import { consola } from 'consola'
+import { resolveSearchBarPosition } from '../utils/search-bar-position'
 
 const { t } = useI18n()
 
@@ -15,6 +16,8 @@ const { setSearchResults, setSelectedLocation, initializeLayers, updateUserLocat
 const { setSearchPending } = useLocationLoadingState()
 const { showUserLocation, userLocationPoint, userLocationAccuracy, isGeoReady, initialPoint, initialAccuracy, hasQueryParams } = useUserLocation()
 const { width: windowWidth, height: windowHeight } = useWindowSize()
+const route = useRoute()
+const searchBarPosition = computed(() => resolveSearchBarPosition(route.query.searchBarPosition))
 
 // Inline composable for map interaction handlers
 function useMapInteractions(options: {
@@ -230,7 +233,15 @@ async function onMapLoad(event: { map: Map }) {
 
 <template>
   <main of-hidden h-dvh>
-    <Search v-model:query="query" v-model:category="category" :autocomplete-locations :autocomplete-geo :autocomplete-geo-weak @navigate="handleNavigate" />
+    <Search
+      v-model:query="query"
+      v-model:category="category"
+      :position="searchBarPosition"
+      :autocomplete-locations
+      :autocomplete-geo
+      :autocomplete-geo-weak
+      @navigate="handleNavigate"
+    />
     <ClientOnly>
       <template #fallback>
         <div flex="~ items-center justify-center" bg-neutral-100 size-screen>
@@ -255,9 +266,9 @@ async function onMapLoad(event: { map: Map }) {
         </MglMap>
       </div>
     </ClientOnly>
-    <MapControls />
-    <CountryBubbles />
-    <LocationCounter />
+    <MapControls :search-bar-position="searchBarPosition" />
+    <CountryBubbles :search-bar-position="searchBarPosition" />
+    <LocationCounter :search-bar-position="searchBarPosition" />
     <DevOnly><MapDebugPanel /></DevOnly>
 
     <LocationDrawer

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import type { Map, MapMouseEvent } from 'maplibre-gl'
 import { consola } from 'consola'
-import { resolveSearchBarPosition } from '../utils/search-bar-position'
+import {
+  resolveSearchBarPosition,
+  SEARCH_BAR_QUERY_PARAM,
+} from '../utils/search-bar-position'
 
 const { t } = useI18n()
 
@@ -17,7 +20,7 @@ const { setSearchPending } = useLocationLoadingState()
 const { showUserLocation, userLocationPoint, userLocationAccuracy, isGeoReady, initialPoint, initialAccuracy, hasQueryParams } = useUserLocation()
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 const route = useRoute()
-const searchBarPosition = computed(() => resolveSearchBarPosition(route.query.searchBarPosition))
+const searchBarPosition = computed(() => resolveSearchBarPosition(route.query[SEARCH_BAR_QUERY_PARAM]))
 
 // Inline composable for map interaction handlers
 function useMapInteractions(options: {

--- a/app/utils/search-bar-position.ts
+++ b/app/utils/search-bar-position.ts
@@ -1,0 +1,12 @@
+export const SEARCH_BAR_QUERY_PARAM = 'searchBarPosition'
+
+export type SearchBarPosition = 'top' | 'bottom'
+
+export const SEARCH_BAR_BOTTOM_UI_OFFSET_PX = 88
+
+export function resolveSearchBarPosition(value: string | Array<string | null> | null | undefined): SearchBarPosition {
+  if (value === 'top' || value === 'bottom')
+    return value
+
+  return 'top'
+}

--- a/app/utils/search-bar-position.ts
+++ b/app/utils/search-bar-position.ts
@@ -3,13 +3,27 @@ export const SEARCH_BAR_QUERY_PARAM = 'searchBarPosition'
 export type SearchBarPosition = 'top' | 'bottom'
 export type SearchNavigationQuery = Record<string, string | null | Array<string | null> | undefined>
 
+export const SEARCH_BAR_BOTTOM_SAFE_OFFSET_PX = 12
 export const SEARCH_BAR_BOTTOM_UI_OFFSET_PX = 88
+export const SEARCH_BAR_BOTTOM_UI_OFFSET_MD_PX = SEARCH_BAR_BOTTOM_UI_OFFSET_PX + 4
+export const SEARCH_BAR_BOTTOM_COUNTER_OFFSET_PX = SEARCH_BAR_BOTTOM_UI_OFFSET_PX - 4
 
 export function resolveSearchBarPosition(value: string | Array<string | null> | null | undefined): SearchBarPosition {
   if (value === 'top' || value === 'bottom')
     return value
 
   return 'top'
+}
+
+export function getBottomSafeAreaInsetPx() {
+  if (typeof document === 'undefined')
+    return 0
+
+  const rawValue = getComputedStyle(document.documentElement)
+    .getPropertyValue('--safe-area-inset-bottom-px')
+    .trim()
+  const safeAreaInset = Number.parseFloat(rawValue)
+  return Number.isFinite(safeAreaInset) ? safeAreaInset : 0
 }
 
 export function getSearchBarNavigationQuery(

--- a/app/utils/search-bar-position.ts
+++ b/app/utils/search-bar-position.ts
@@ -1,6 +1,7 @@
 export const SEARCH_BAR_QUERY_PARAM = 'searchBarPosition'
 
 export type SearchBarPosition = 'top' | 'bottom'
+export type SearchNavigationQuery = Record<string, string | null | Array<string | null> | undefined>
 
 export const SEARCH_BAR_BOTTOM_UI_OFFSET_PX = 88
 
@@ -9,4 +10,19 @@ export function resolveSearchBarPosition(value: string | Array<string | null> | 
     return value
 
   return 'top'
+}
+
+export function getSearchBarNavigationQuery(
+  query: SearchNavigationQuery,
+  position: SearchBarPosition,
+) {
+  const nextQuery = { ...query }
+
+  if (position === 'bottom') {
+    nextQuery[SEARCH_BAR_QUERY_PARAM] = 'bottom'
+    return nextQuery
+  }
+
+  delete nextQuery[SEARCH_BAR_QUERY_PARAM]
+  return nextQuery
 }

--- a/tests/search-bar-position.test.ts
+++ b/tests/search-bar-position.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getSearchBarNavigationQuery,
   resolveSearchBarPosition,
   SEARCH_BAR_BOTTOM_UI_OFFSET_PX,
   SEARCH_BAR_QUERY_PARAM,
@@ -41,5 +42,75 @@ describe('search bar position', () => {
 
   it('keeps bottom overlay spacing positive', () => {
     expect(SEARCH_BAR_BOTTOM_UI_OFFSET_PX).toBeGreaterThan(0)
+  })
+
+  it('preserves the bottom position in navigation query state', () => {
+    expect(getSearchBarNavigationQuery({}, 'bottom')).toEqual({
+      searchBarPosition: 'bottom',
+    })
+  })
+
+  it('preserves unrelated query params in navigation query state', () => {
+    expect(getSearchBarNavigationQuery({ lang: 'de' }, 'bottom')).toEqual({
+      lang: 'de',
+      searchBarPosition: 'bottom',
+    })
+  })
+
+  it('preserves arbitrary scalar query params in navigation query state', () => {
+    expect(getSearchBarNavigationQuery({
+      lang: 'de',
+      ref: 'newsletter',
+      page: '2',
+      view: 'grid',
+    }, 'bottom')).toEqual({
+      lang: 'de',
+      ref: 'newsletter',
+      page: '2',
+      view: 'grid',
+      searchBarPosition: 'bottom',
+    })
+  })
+
+  it('preserves repeated and nullable query params in navigation query state', () => {
+    expect(getSearchBarNavigationQuery({
+      lang: ['de', 'en'],
+      tags: ['coffee', null, 'bakery'],
+      region: null,
+    }, 'bottom')).toEqual({
+      lang: ['de', 'en'],
+      tags: ['coffee', null, 'bakery'],
+      region: null,
+      searchBarPosition: 'bottom',
+    })
+  })
+
+  it('removes only the search bar position query param for top mode', () => {
+    expect(getSearchBarNavigationQuery({
+      lang: 'de',
+      searchBarPosition: 'bottom',
+    }, 'top')).toEqual({
+      lang: 'de',
+    })
+  })
+
+  it('does not mutate the incoming query object', () => {
+    const query = {
+      lang: 'de',
+      searchBarPosition: 'bottom',
+      tags: ['coffee', 'bakery'],
+    }
+
+    const nextQuery = getSearchBarNavigationQuery(query, 'top')
+
+    expect(nextQuery).toEqual({
+      lang: 'de',
+      tags: ['coffee', 'bakery'],
+    })
+    expect(query).toEqual({
+      lang: 'de',
+      searchBarPosition: 'bottom',
+      tags: ['coffee', 'bakery'],
+    })
   })
 })

--- a/tests/search-bar-position.test.ts
+++ b/tests/search-bar-position.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getBottomSafeAreaInsetPx,
   getSearchBarNavigationQuery,
   resolveSearchBarPosition,
+  SEARCH_BAR_BOTTOM_COUNTER_OFFSET_PX,
+  SEARCH_BAR_BOTTOM_SAFE_OFFSET_PX,
+  SEARCH_BAR_BOTTOM_UI_OFFSET_MD_PX,
   SEARCH_BAR_BOTTOM_UI_OFFSET_PX,
   SEARCH_BAR_QUERY_PARAM,
 } from '../app/utils/search-bar-position'
@@ -42,6 +46,12 @@ describe('search bar position', () => {
 
   it('keeps bottom overlay spacing positive', () => {
     expect(SEARCH_BAR_BOTTOM_UI_OFFSET_PX).toBeGreaterThan(0)
+  })
+
+  it('derives overlay offsets from the shared bottom offset constant', () => {
+    expect(SEARCH_BAR_BOTTOM_SAFE_OFFSET_PX).toBe(12)
+    expect(SEARCH_BAR_BOTTOM_UI_OFFSET_MD_PX).toBe(SEARCH_BAR_BOTTOM_UI_OFFSET_PX + 4)
+    expect(SEARCH_BAR_BOTTOM_COUNTER_OFFSET_PX).toBe(SEARCH_BAR_BOTTOM_UI_OFFSET_PX - 4)
   })
 
   it('preserves the bottom position in navigation query state', () => {
@@ -112,5 +122,47 @@ describe('search bar position', () => {
       searchBarPosition: 'bottom',
       tags: ['coffee', 'bakery'],
     })
+  })
+
+  it('reads the bottom safe-area inset from the shared CSS custom property', () => {
+    const originalDocument = globalThis.document
+    const originalGetComputedStyle = globalThis.getComputedStyle
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {},
+    })
+    globalThis.getComputedStyle = (() => ({
+      getPropertyValue: (property: string) => property === '--safe-area-inset-bottom-px' ? '34px' : '',
+    })) as typeof getComputedStyle
+
+    expect(getBottomSafeAreaInsetPx()).toBe(34)
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: originalDocument,
+    })
+    globalThis.getComputedStyle = originalGetComputedStyle
+  })
+
+  it('falls back to zero safe-area inset when the CSS property is missing', () => {
+    const originalDocument = globalThis.document
+    const originalGetComputedStyle = globalThis.getComputedStyle
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {},
+    })
+    globalThis.getComputedStyle = (() => ({
+      getPropertyValue: () => '',
+    })) as typeof getComputedStyle
+
+    expect(getBottomSafeAreaInsetPx()).toBe(0)
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: originalDocument,
+    })
+    globalThis.getComputedStyle = originalGetComputedStyle
   })
 })

--- a/tests/search-bar-position.test.ts
+++ b/tests/search-bar-position.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveSearchBarPosition,
+  SEARCH_BAR_BOTTOM_UI_OFFSET_PX,
+  SEARCH_BAR_QUERY_PARAM,
+} from '../app/utils/search-bar-position'
+
+describe('search bar position', () => {
+  it('uses the expected query param name', () => {
+    expect(SEARCH_BAR_QUERY_PARAM).toBe('searchBarPosition')
+  })
+
+  it('defaults to top when the query param is missing', () => {
+    expect(resolveSearchBarPosition(undefined)).toBe('top')
+  })
+
+  it('defaults to top when the query param is null', () => {
+    expect(resolveSearchBarPosition(null)).toBe('top')
+  })
+
+  it('accepts the top position', () => {
+    expect(resolveSearchBarPosition('top')).toBe('top')
+  })
+
+  it('accepts the bottom position', () => {
+    expect(resolveSearchBarPosition('bottom')).toBe('bottom')
+  })
+
+  it('falls back to top for invalid values', () => {
+    expect(resolveSearchBarPosition('left')).toBe('top')
+  })
+
+  it('falls back to top for repeated values', () => {
+    expect(resolveSearchBarPosition(['bottom', 'top'])).toBe('top')
+  })
+
+  it('falls back to top for repeated values that include null', () => {
+    expect(resolveSearchBarPosition([null, 'bottom'])).toBe('top')
+  })
+
+  it('keeps bottom overlay spacing positive', () => {
+    expect(SEARCH_BAR_BOTTOM_UI_OFFSET_PX).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add `searchBarPosition` route query parsing with `top` and `bottom` modes
- update the map page to pass the resolved search bar position into the search UI and bottom overlays
- anchor the search input and combobox content to the bottom when requested, including safe-area spacing
- shift map controls, location counter, and country bubble edge placement to avoid overlap in bottom mode
- add unit coverage for valid, invalid, null, and repeated query param values

## Testing
- `pnpm test`
- `pnpm run typecheck`